### PR TITLE
add support for 'disconnect' from Jenkins master cli command

### DIFF
--- a/devnest/lib/node.py
+++ b/devnest/lib/node.py
@@ -770,6 +770,15 @@ class Node(object):
         self._set_node_config()
         return self._config
 
+    def disconnect(self, msg='disconnected_by_devnest'):
+        """Disconnect the node from Jenkins master
+        """
+        node_url = self.get_node_url()
+
+        LOG.info('Disconnecting %s from Jenkins master' % self.node_name)
+
+        self.jenkins.requester.post_and_confirm_status("%s/doDisconnect?offlineMessage=%s" % (node_url, msg), data={} )
+
     def _update_node_with_node_details(self, node_details):
         """Update node with NodeDetails data.
 


### PR DESCRIPTION
Sometimes it's required to disconnect a slave from the master
i.e.: to stop slave.jar and allow reconfiguration of the slave.

RHOSINFRA-2560