### PR TITLE
Python3.8 deprecates platform.linux_distribution

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ jenkinsapi
 terminaltables>=3.1.0
 urllib3
 requests
+distro

--- a/setup.py
+++ b/setup.py
@@ -23,14 +23,17 @@ try:
 except ImportError:
     pass
 import os
-import platform
+import distro
 
 
 setup(
     setup_requires=['pbr>=3.0.0', 'setuptools>=17.1'],
     pbr=True)
 
-if all(platform.linux_distribution(supported_dists="redhat")):
+SELINUX_DISTROS = ["fedora", "rhel", "centos" ]
+
+if distro.linux_distribution(full_distribution_name=False)[0] in SELINUX_DISTROS:
+
     # For RedHat based systems, get selinux binding
     try:
         import selinux


### PR DESCRIPTION
Fedora32 introduced python3.8 which deprecates the linux_distribution
function from the platform module. This replaces deprecated function
with the one that is supported for both python2.x (starting from
python2.6) and python3.x.