### PR TITLE
Improve error handling for missing values in node reservation details

### DIFF
--- a/devnest/lib/node.py
+++ b/devnest/lib/node.py
@@ -670,7 +670,7 @@ class Node(object):
                                                        owner,
                                                        reprovision_pending)
 
-            except ValueError:
+            except (TypeError, ValueError):
                 LOG.debug('Could not read reservation data for node %s,'
                           ' invalid json format: %s' % (self.get_name(),
                                                         offline_cause_reason))

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ setup(
     setup_requires=['pbr>=3.0.0', 'setuptools>=17.1'],
     pbr=True)
 
-SELINUX_DISTROS = ["fedora", "rhel", "centos" ]
+SELINUX_DISTROS = ["fedora", "rhel", "centos"]
 
 if distro.linux_distribution(full_distribution_name=False)[0] in SELINUX_DISTROS:
 


### PR DESCRIPTION
Today we noticed that for missing startTime and endTime keys
in node configuration, on Python3 the raised expection was
TypeError. This change makes DevNest display proper error
message in such case instead of traceback.