### PR TITLE
Add noqe for import in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,8 +27,8 @@ setup(
     setup_requires=['pbr>=3.0.0', 'setuptools>=17.1', 'distro', 'selinux'],
     pbr=True)
 
-import os
-import distro
+import os  # noqa: E402
+import distro  # noqa: E402
 
 SELINUX_DISTROS = ["fedora", "rhel", "centos"]
 


### PR DESCRIPTION
We can safely skip linting import in setup.py
which is required to work-around issue with
new jenkins master.