### PR TITLE
Catch all exceptions from nodes

### DIFF
--- a/devnest/lib/node.py
+++ b/devnest/lib/node.py
@@ -675,6 +675,10 @@ class Node(object):
                           ' invalid json format: %s' % (self.get_name(),
                                                         offline_cause_reason))
 
+            except Exception:
+                LOG.error('Caught exception for node %s' % self.get_name())
+                raise
+
         return reservation_info
 
     def _get_total_physical_mem(self):


### PR DESCRIPTION
At times we receive various exceptions due to people putting
values freely to the Jenkins agents descriptions. Recently
setting '3.11' as agent description caused AttributeError
because apparently json.loads() accepts numerical values.

The proposal here is to catch all exceptions, display the message
with name of the node that caused such failure, then raise
again the original exception for traceback.