### PR TITLE
Catch AttributeError from node

### DIFF
--- a/devnest/lib/node.py
+++ b/devnest/lib/node.py
@@ -670,7 +670,7 @@ class Node(object):
                                                        owner,
                                                        reprovision_pending)
 
-            except (TypeError, ValueError):
+            except (AttributeError, TypeError, ValueError):
                 LOG.debug('Could not read reservation data for node %s,'
                           ' invalid json format: %s' % (self.get_name(),
                                                         offline_cause_reason))


### PR DESCRIPTION
It turns out that json.loads accept strings with numerical values,
such as '3.11', and raises no exception. Then there is a problem
in function where we treat the value as dictionary with doing .get(),
which results in AttributeError. This commit catches that.