### PR TITLE
Fix error devnest command py313

### DIFF
--- a/devnest/lib/cli.py
+++ b/devnest/lib/cli.py
@@ -137,7 +137,7 @@ class JenkinsNodeShell(object):
 
         # Main parser
         parser = argparse.ArgumentParser(prog='devnest',
-                                         parents=[config_group],
+                                         parents=[config_parser],
                                          description='CLI to reserve, release'
                                          ' or manage nodes in DevNest.',
                                          formatter_class=formatter,


### PR DESCRIPTION
raise TypeError('parents must be a list of ArgumentParser')


ccamposr@fedora:~/devnest$ devnest --help
Traceback (most recent call last):
  File "/home/ccamposr/.local/bin/devnest", line 8, in <module>
    sys.exit(main())
             ~~~~^^
  File "/home/ccamposr/.local/lib/python3.13/site-packages/devnest/lib/cli.py", line 709, in main
    JenkinsNodeShell().main(args)
    ~~~~~~~~~~~~~~~~~~~~~~~^^^^^^
  File "/home/ccamposr/.local/lib/python3.13/site-packages/devnest/lib/cli.py", line 389, in main
    parser_args = self.parse_args(argv)
  File "/home/ccamposr/.local/lib/python3.13/site-packages/devnest/lib/cli.py", line 362, in parse_args
    parser = self.get_base_parser()
  File "/home/ccamposr/.local/lib/python3.13/site-packages/devnest/lib/cli.py", line 139, in get_base_parser
    parser = argparse.ArgumentParser(prog='devnest',
                                     parents=[config_group],
    ...<2 lines>...
                                     formatter_class=formatter,
                                     add_help=False)
  File "/usr/lib64/python3.13/argparse.py", line 1806, in __init__
    raise TypeError('parents must be a list of ArgumentParser')
TypeError: parents must be a list of ArgumentParser
